### PR TITLE
Fix script_rigidbody_trigger sample bug

### DIFF
--- a/script_rigidbody_trigger/Sources/arm/Trigger.hx
+++ b/script_rigidbody_trigger/Sources/arm/Trigger.hx
@@ -24,15 +24,17 @@ class Trigger extends iron.Trait {
 			// TODO: replace with notifyOnCollisionEnter or notifyOnTriggerEnter once implemented
 			// ref: https://github.com/armory3d/armory/issues/331
 			var rbs = physics.getContacts(object.getTrait(RigidBody));
+			var visible = false;
+
 			if (rbs != null) {
 				for (rb in rbs){
 					if(rb.object.name == "Cube"){
-						obj.visible = true;
+						visible = true;
 					}
 				}
-			} else {
-				obj.visible = false;
 			}
+
+			obj.visible = visible;
 		});
 	}
 }


### PR DESCRIPTION
Script from examples didn't work as it should. After leaving trigger area sphere didn't disappear as it should.
So I found tiny logic bug and fixed it.